### PR TITLE
Improve wp_enqueue_script() documentation comment

### DIFF
--- a/plugin-name/public/class-plugin-name-public.php
+++ b/plugin-name/public/class-plugin-name-public.php
@@ -20,7 +20,8 @@
  * @subpackage Plugin_Name/public
  * @author     Your Name <email@example.com>
  */
-class Plugin_Name_Public {
+class Plugin_Name_Public
+{
 
 	/**
 	 * The ID of this plugin.
@@ -47,11 +48,11 @@ class Plugin_Name_Public {
 	 * @param      string    $plugin_name       The name of the plugin.
 	 * @param      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct($plugin_name, $version)
+	{
 
 		$this->plugin_name = $plugin_name;
 		$this->version = $version;
-
 	}
 
 	/**
@@ -59,7 +60,8 @@ class Plugin_Name_Public {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_styles() {
+	public function enqueue_styles()
+	{
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -73,8 +75,7 @@ class Plugin_Name_Public {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/plugin-name-public.css', array(), $this->version, 'all' );
-
+		wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/plugin-name-public.css', array(), $this->version, 'all');
 	}
 
 	/**
@@ -82,22 +83,22 @@ class Plugin_Name_Public {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts()
+	{
 
 		/**
 		 * This function is provided for demonstration purposes only.
+		 * It registers and enqueues the plugin's JavaScript file.
 		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Plugin_Name_Loader as all of the hooks are defined
-		 * in that particular class.
+		 * With the current plugin structure, an instance of this class
+		 * is created by Plugin_Name and then passed to add_action()
+		 * defined in Plugin_Name_Loader.
 		 *
 		 * The Plugin_Name_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
+		 * between the defined hooks and the functions defined in
+		 * this class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/plugin-name-public.js', array( 'jquery' ), $this->version, false );
-
+		wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/plugin-name-public.js', array('jquery'), $this->version, false);
 	}
-
 }


### PR DESCRIPTION
## Description
This PR improves the documentation comment for the [enqueue_scripts()](cci:1://file:///c:/Users/vinay/OneDrive/Desktop/WordPress-Plugin-Boilerplate/plugin-name/public/class-plugin-name-public.php:80:1-102:2) method in the [Plugin_Name_Public](cci:2://file:///c:/Users/vinay/OneDrive/Desktop/WordPress-Plugin-Boilerplate/plugin-name/public/class-plugin-name-public.php:22:0-103:1) class to provide clearer and more accurate information about how the function works within the plugin's architecture.

### Changes Made:
- Updated the comment to accurately describe that the function registers and enqueues the plugin's JavaScript file
- Clarified that an instance of the class is automatically created by [Plugin_Name](cci:2://file:///c:/Users/vinay/OneDrive/Desktop/WordPress-Plugin-Boilerplate/plugin-name/public/class-plugin-name-public.php:22:0-103:1) and passed to `add_action()` in `Plugin_Name_Loader`
- Made the explanation more precise about the plugin's hook system

### Why This Change is Important:
The previous comment was somewhat misleading as it suggested that developers need to manually pass an instance of the class to the `run()` function, when in fact this is handled automatically by the plugin's architecture. This update makes the documentation more accurate and helpful for developers who are new to the WordPress Plugin Boilerplate.

### Related Issue:
Fixes #592